### PR TITLE
Add lock feature

### DIFF
--- a/Kernel/Config/Files/QuickOwnerChange.xml
+++ b/Kernel/Config/Files/QuickOwnerChange.xml
@@ -79,6 +79,17 @@
             <String Regex="">rw</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="QuickOwnerChange::SetLock" Required="0" Valid="1">
+        <Description Translatable="1">If enabled, the ticket will be locked after change</Description>
+        <Group>QuickOwnerChange</Group>
+        <SubGroup>Core</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0">No</Item>
+                <Item Key="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="QuickOwnerChange::SetResponsible" Required="0" Valid="1">
         <Description Translatable="1">If enabled, the responsible is set to the selected owner</Description>
         <Group>QuickOwnerChange</Group>

--- a/Kernel/Modules/AgentTicketOwnerChangeBulk.pm
+++ b/Kernel/Modules/AgentTicketOwnerChangeBulk.pm
@@ -78,6 +78,22 @@ sub Run {
             NewUserID => $ID,
             UserID    => $Self->{UserID},
         );
+        
+        if ( $ConfigObject->Get('QuickOwnerChange::SetLock') ) {
+	    if ($ID == 1 ) {
+	      $TicketObject->TicketLockSet(
+		  Lock     => 'unlock',
+		  TicketID  => $TicketID,
+		  UserID    => $Self->{UserID},
+	      );
+	    } else {
+	      $TicketObject->TicketLockSet(
+		  Lock     => 'lock',
+		  TicketID  => $TicketID,
+		  UserID    => $Self->{UserID},
+	      );
+	    }
+        }
 
         if ( $ConfigObject->Get('QuickOwnerChange::SetResponsible') ) {
             $TicketObject->TicketResponsibleSet(


### PR DESCRIPTION
After a change the new user has to lock it again. With this feature it isn't necessary. A change to Admin-OTRS unlocks it no matter about the settings.

Is it possible to hide the dropdown for certain user?

Greetings Thomas
