### PR TITLE
Hungarian translation and small fixes

### DIFF
--- a/Kernel/Config/Files/QuickOwnerChange.xml
+++ b/Kernel/Config/Files/QuickOwnerChange.xml
@@ -1,34 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <otrs_config version="1.0" init="Config">
     <ConfigItem Name="Frontend::Module###AgentQuickOwnerChange" Required="0" Valid="1">
-        <Description Lang="en">Frontend module registration for the QuickOwnerChange agent interface.</Description>
-        <Description Lang="de">Frontendmodul-Registration für das QuickOwnerChange Agenten Interface.</Description>
+        <Description Translatable="1">Frontend module registration for the QuickOwnerChange agent interface.</Description>
         <Group>QuickOwnerChange</Group>
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>QuickOwnerChange</Description>
+                <Description Translatable="1">Quick owner change.</Description>
                 <NavBarName></NavBarName>
-                <Title>QuickOwnerChange</Title>
+                <Title Translatable="1">Quick Owner Change</Title>
             </FrontendModuleReg>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::Module###AgentTicketOwnerChangeBulk" Required="0" Valid="1">
-        <Description Lang="en">Frontend module registration for the bulk QuickOwnerChange agent interface.</Description>
-        <Description Lang="de">Frontendmodul-Registration für das MassenQuickOwnerChange Agenten Interface.</Description>
+        <Description Translatable="1">Frontend module registration for the bulk QuickOwnerChange agent interface.</Description>
         <Group>QuickOwnerChange</Group>
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>Bulk QuickOwnerChange</Description>
+                <Description Translatable="1">Bulk quick owner change.</Description>
                 <NavBarName></NavBarName>
-                <Title>Bulk QuickOwnerChange</Title>
+                <Title Translatable="1">Bulk Quick Owner Change</Title>
             </FrontendModuleReg>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::Output::FilterElementPost###OutputFilterOwnerChange" Required="0" Valid="1">
-        <Description Lang="en">Modul to show OuputfilterOwnerChange.</Description>
-        <Description Lang="de">Modul zum Anzeigen von OuputfilterOwnerChange.</Description>
+        <Description Translatable="1">Module to show OuputfilterOwnerChange.</Description>
         <Group>QuickOwnerChange</Group>
         <SubGroup>OutputFilterOwnerChange</SubGroup>
         <Setting>
@@ -44,8 +41,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="Frontend::Output::FilterElementPost###OutputFilterOwnerChangeTicketView" Required="0" Valid="1">
-        <Description Lang="en">Modul to show OuputfilterOwnerChange in ticket overviews.</Description>
-        <Description Lang="de">Modul zum Anzeigen von OuputfilterOwnerChange in Ticketübersichten.</Description>
+        <Description Translatable="1">Module to show OuputfilterOwnerChange in ticket overviews.</Description>
         <Group>QuickOwnerChange</Group>
         <SubGroup>OutputFilterOwnerChange</SubGroup>
         <Setting>
@@ -62,15 +58,6 @@
             </Hash>
         </Setting>
     </ConfigItem>
-    <ConfigItem Name="QuickOwnerChange::NoneLabel" Required="0" Valid="1">
-        <Description Lang="en">Label for the NULL option in dropdown.</Description>
-        <Description Lang="de">Text für die Leer-Option im Dropdown.</Description>
-        <Group>QuickOwnerChange</Group>
-        <SubGroup>Core</SubGroup>
-        <Setting>
-            <String Regex="">QuickOwnerChange</String>
-        </Setting>
-    </ConfigItem>
     <ConfigItem Name="QuickOwnerChange::Permissions" Required="0" Valid="1">
         <Description Translatable="1">Minimum permissions for the agent on the queue of the ticket to be listed as a possible owner.</Description>
         <Group>QuickOwnerChange</Group>
@@ -80,29 +67,29 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="QuickOwnerChange::SetLock" Required="0" Valid="1">
-        <Description Translatable="1">If enabled, the ticket will be locked after change</Description>
+        <Description Translatable="1">If enabled, the ticket will be locked after change.</Description>
         <Group>QuickOwnerChange</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
             <Option SelectedID="0">
-                <Item Key="0">No</Item>
-                <Item Key="1">Yes</Item>
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
             </Option>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="QuickOwnerChange::SetResponsible" Required="0" Valid="1">
-        <Description Translatable="1">If enabled, the responsible is set to the selected owner</Description>
+        <Description Translatable="1">If enabled, the responsible is set to the selected owner.</Description>
         <Group>QuickOwnerChange</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
             <Option SelectedID="0">
-                <Item Key="0">No</Item>
-                <Item Key="1">Yes</Item>
+                <Item Key="0" Translatable="1">No</Item>
+                <Item Key="1" Translatable="1">Yes</Item>
             </Option>
         </Setting>
     </ConfigItem>
     <ConfigItem Name="QuickOwnerChange::OwnerGroup" Required="0" Valid="0">
-        <Description Translatable="1">If enabled, the possible owners have to be a member of the defined group</Description>
+        <Description Translatable="1">If enabled, the possible owners have to be a member of the defined group.</Description>
         <Group>QuickOwnerChange</Group>
         <SubGroup>Core</SubGroup>
         <Setting>
@@ -110,7 +97,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="QuickOwnerChange::QueueGroups" Required="0" Valid="0">
-        <Description Translatable="1">If enabled, the possible owners are defined by the queue the tickets is assigned to and the group</Description>
+        <Description Translatable="1">If enabled, the possible owners are defined by the queue the tickets is assigned to and the group.</Description>
         <Group>QuickOwnerChange</Group>
         <SubGroup>Core</SubGroup>
         <Setting>

--- a/Kernel/Language/de_QuickOwnerChange.pm
+++ b/Kernel/Language/de_QuickOwnerChange.pm
@@ -1,0 +1,59 @@
+# --
+# Kernel/Language/de_QuickOwnerChange.pm - the German translation for QuickOwnerChange
+# Copyright (C) 2014-2016 Perl-Services, http://www.perl-services.de
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Language::de_QuickOwnerChange;
+
+use strict;
+use warnings;
+
+use utf8;
+
+our $VERSION = 0.01;
+
+sub Data {
+    my $Self = shift;
+
+    my $Lang = $Self->{Translation};
+
+    return if ref $Lang ne 'HASH';
+
+    # Kernel/Config/Files/QuickOwnerChange.xml
+    $Lang->{'Frontend module registration for the QuickOwnerChange agent interface.'} =
+        'Frontendmodul-Registration für das QuickOwnerChange Agenten Interface.';
+    $Lang->{'Quick owner change.'} = '';
+    $Lang->{'Quick Owner Change'} = '';
+    $Lang->{'Frontend module registration for the bulk QuickOwnerChange agent interface.'} =
+        'Frontendmodul-Registration für das MassenQuickOwnerChange Agenten Interface.';
+    $Lang->{'Bulk quick owner change.'} = '';
+    $Lang->{'Bulk Quick Owner Change'} = '';
+    $Lang->{'Module to show OuputfilterOwnerChange.'} = 'Modul zum Anzeigen von OuputfilterOwnerChange.';
+    $Lang->{'Module to show OuputfilterOwnerChange in ticket overviews.'} =
+        'Modul zum Anzeigen von OuputfilterOwnerChange in Ticketübersichten.';
+    $Lang->{'Minimum permissions for the agent on the queue of the ticket to be listed as a possible owner.'} = '';
+    $Lang->{'If enabled, the ticket will be locked after change.'} = '';
+    $Lang->{'If enabled, the responsible is set to the selected owner.'} = '';
+    $Lang->{'If enabled, the possible owners have to be a member of the defined group.'} = '';
+    $Lang->{'If enabled, the possible owners are defined by the queue the tickets is assigned to and the group.'} = '';
+    $Lang->{'Yes'} = 'Ja';
+    $Lang->{'No'} = 'Nein';
+
+    # Kernel/Modules/AgentTicketOwnerChangeBulk.pm
+    $Lang->{'No TicketID is given!'} = 'Keine TicketID übermittelt!';
+    $Lang->{'Please contact the administrator.'} = '';
+    $Lang->{'No OwnerID is given!'} = '';
+    $Lang->{'No access to these tickets (IDs: %s)'} = '';
+
+    # Kernel/Output/HTML/Templates/Standard/QuickOwnerChangeSnippet.tt
+    $Lang->{'QuickOwnerChange ticket'} = '';
+    $Lang->{'QuickOwnerChange'} = '';
+
+    return 1;
+}
+
+1;

--- a/Kernel/Language/hu_QuickOwnerChange.pm
+++ b/Kernel/Language/hu_QuickOwnerChange.pm
@@ -1,0 +1,65 @@
+# --
+# Kernel/Language/hu_QuickOwnerChange.pm - the Hungarian translation for QuickOwnerChange
+# Copyright (C) 2014-2016 Perl-Services, http://www.perl-services.de
+# Copyright (C) 2016 Balázs Úr, http://www.otrs-megoldasok.hu
+# --
+# This software comes with ABSOLUTELY NO WARRANTY. For details, see
+# the enclosed file COPYING for license information (AGPL). If you
+# did not receive this file, see http://www.gnu.org/licenses/agpl.txt.
+# --
+
+package Kernel::Language::hu_QuickOwnerChange;
+
+use strict;
+use warnings;
+
+use utf8;
+
+our $VERSION = 0.01;
+
+sub Data {
+    my $Self = shift;
+
+    my $Lang = $Self->{Translation};
+
+    return if ref $Lang ne 'HASH';
+
+    # Kernel/Config/Files/QuickOwnerChange.xml
+    $Lang->{'Frontend module registration for the QuickOwnerChange agent interface.'} =
+        'Előtétprogram-modul regisztráció a gyors tulajdonosváltás ügyintézői felülethez.';
+    $Lang->{'Quick owner change.'} = 'Gyors tulajdonosváltás.';
+    $Lang->{'Quick Owner Change'} = 'Gyors tulajdonosváltás';
+    $Lang->{'Frontend module registration for the bulk QuickOwnerChange agent interface.'} =
+        'Előtétprogram-modul regisztráció a tömeges gyors tulajdonosváltás ügyintézői felülethez.';
+    $Lang->{'Bulk quick owner change.'} = 'Tömeges gyors tulajdonosváltás.';
+    $Lang->{'Bulk Quick Owner Change'} = 'Tömeges gyors tulajdonosváltás';
+    $Lang->{'Module to show OuputfilterOwnerChange.'} = 'Egy modul a tulajdonosváltás kimenetszűrő megjelenítéséhez.';
+    $Lang->{'Module to show OuputfilterOwnerChange in ticket overviews.'} =
+        'Egy modul a tulajdonosváltás kimenetszűrő megjelenítéséhez a jegyáttekintőkben.';
+    $Lang->{'Minimum permissions for the agent on the queue of the ticket to be listed as a possible owner.'} =
+        'Az ügyintéző legkisebb jogosultságai a jegy várólistáján, hogy lehetséges tulajdonosként legyen felsorolva.';
+    $Lang->{'If enabled, the ticket will be locked after change.'} =
+        'Ha engedélyezve van, akkor a jegy zárolva lesz a változtatás után.';
+    $Lang->{'If enabled, the responsible is set to the selected owner.'} =
+        'Ha engedélyezve van, akkor a felelős is be lesz állítva a választott tulajdonosra.';
+    $Lang->{'If enabled, the possible owners have to be a member of the defined group.'} =
+        'Ha engedélyezve van, akkor a lehetséges tulajdonosoknak a meghatározott csoport tagjának kell lennie.';
+    $Lang->{'If enabled, the possible owners are defined by the queue the tickets is assigned to and the group.'} =
+        'Ha engedélyezve van, akkor a lehetséges tulajdonosokat a csoport, valamint az a várólista határozza meg, amelyhez a jegyek hozzá vannak rendelve.';
+    $Lang->{'Yes'} = 'Igen';
+    $Lang->{'No'} = 'Nem';
+
+    # Kernel/Modules/AgentTicketOwnerChangeBulk.pm
+    $Lang->{'No TicketID is given!'} = 'Nincs jegyazonosító megadva!';
+    $Lang->{'Please contact the administrator.'} = 'Vegye fel a kapcsolatot a rendszergazdával.';
+    $Lang->{'No OwnerID is given!'} = 'Nincs tulajdonosazonosító megadva!';
+    $Lang->{'No access to these tickets (IDs: %s)'} = 'Nincs hozzáférés ezekhez a jegyekhez (azonosítók: %s)';
+
+    # Kernel/Output/HTML/Templates/Standard/QuickOwnerChangeSnippet.tt
+    $Lang->{'QuickOwnerChange ticket'} = 'Jegy gyors tulajdonosváltása';
+    $Lang->{'QuickOwnerChange'} = 'Gyors tulajdonosváltás';
+
+    return 1;
+}
+
+1;

--- a/Kernel/Modules/AgentTicketOwnerChangeBulk.pm
+++ b/Kernel/Modules/AgentTicketOwnerChangeBulk.pm
@@ -12,6 +12,8 @@ package Kernel::Modules::AgentTicketOwnerChangeBulk;
 use strict;
 use warnings;
 
+use Kernel::Language qw(Translatable);
+
 our @ObjectDependencies = qw(
     Kernel::Config
     Kernel::System::Web::Request
@@ -43,15 +45,15 @@ sub Run {
     # check needed stuff
     if ( !@TicketIDs ) {
         return $LayoutObject->ErrorScreen(
-            Message => 'No TicketID is given!',
-            Comment => 'Please contact the admin.',
+            Message => Translatable('No TicketID is given!'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
     if ( !$ID ) {
         return $LayoutObject->ErrorScreen(
-            Message => 'No OwnerID is given!',
-            Comment => 'Please contact the admin.',
+            Message => Translatable('No OwnerID is given!'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -116,8 +118,8 @@ sub Run {
     }
     else {
         return $LayoutObject->ErrorScreen(
-            Message => 'No Access to these Tickets (IDs: ' . join( ", ", @NoAccess ) . ')',
-            Comment => 'Please contact the admin.',
+            Message => $LayoutObject->{LanguageObject}->Translate( 'No access to these tickets (IDs: %s)', join( ", ", @NoAccess ) ),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 }

--- a/Kernel/Output/HTML/FilterElementPost/OwnerChange.pm
+++ b/Kernel/Output/HTML/FilterElementPost/OwnerChange.pm
@@ -82,14 +82,15 @@ sub Run {
         my @Data = map{ { Key => $_, Value => $User{$_} } }sort{ $User{$a} cmp $User{$b} }keys %User;
         
         unshift @Data, {
-            Key => '', 
-            Value => ' - ' . ($ConfigObject->Get( 'QuickOwnerChange::NoneLabel' ) || 'QuickOwnerChange')  . ' - ',
+            Key => 0, 
+            Value => ' - ' . $LayoutObject->{LanguageObject}->Translate( 'Quick Owner Change' ) . ' - ',
         };
 
         my $Select = $LayoutObject->BuildSelection(
             Name       => 'QuickOwnerChange',
             Data       => \@Data,
-            SelectedID => '',
+            SelectedID => 0,
+            Class      => 'Modernize',
         );
         
         my $Snippet = $LayoutObject->Output(

--- a/Kernel/Output/HTML/FilterElementPost/OwnerChangeTicketView.pm
+++ b/Kernel/Output/HTML/FilterElementPost/OwnerChangeTicketView.pm
@@ -89,15 +89,17 @@ sub Run {
     my @Data = map{ { Key => $_, Value => $User{$_} } }sort{ $User{$a} cmp $User{$b} }keys %User;
     
     unshift @Data, {
-        Key => '', 
-        Value => ' - ' . ($ConfigObject->Get( 'QuickOwnerChange::NoneLabel' ) || 'QuickOwnerChange')  . ' - ',
+        Key => 0, 
+        Value => ' - ' . $LayoutObject->{LanguageObject}->Translate( 'Quick Owner Change' )  . ' - ',
     };
     
     my $Select = $LayoutObject->BuildSelection(
-        Data         => \@Data,
-        Name         => 'QuickOwnerChange',
-        Size         => 1,
-        HTMLQuote    => 1,
+        Data       => \@Data,
+        Name       => 'QuickOwnerChange',
+        Size       => 1,
+        HTMLQuote  => 1,
+        SelectedID => 0,
+        Class      => 'Modernize',
     );
 
     my $Snippet = $LayoutObject->Output(

--- a/Kernel/Output/HTML/Templates/Standard/QuickOwnerChangeSnippetTicketView.tt
+++ b/Kernel/Output/HTML/Templates/Standard/QuickOwnerChangeSnippetTicketView.tt
@@ -8,7 +8,7 @@
 # --
 
                     <li class="Bulk AlwaysPresent [% Data.Class | html %]">
-                        <form title="[% Translate("QuickOwnerChange ticket") | html %] action="[% Env("CGIHandle") | html %] method="post" name="quickownerchange" id="quickownerchange">
+                        <form title="[% Translate("QuickOwnerChange ticket") | html %]" action="[% Env("CGIHandle") | html %]" method="post" name="quickownerchange" id="quickownerchange">
                             <input type="hidden" name="Action" value="AgentTicketOwnerChangeBulk"/>
                             <label for="QuickOwnerChange" class="InvisibleText">[% Translate("QuickOwnerChange") | html %]:</label>
                             [% Data.Select %]

--- a/QuickOwnerChange.sopm
+++ b/QuickOwnerChange.sopm
@@ -2,15 +2,18 @@
 <otrs_package version="1.0">
     <!-- GENERATED WITH OTRS::OPM::Maker::Command::sopm (1.33) -->
     <Name>QuickOwnerChange</Name>
-    <Version>5.0.4</Version>
+    <Version>5.0.5</Version>
     <Framework>5.0.x</Framework>
     <Vendor>Perl-Services.de</Vendor>
     <URL>http://www.perl-services.de</URL>
-    <Description Lang="de">Ticketbesitzer leicht wechseln</Description>
-    <Description Lang="en">Change ticket owners easily</Description>
+    <Description Lang="de">Ticketbesitzer leicht wechseln.</Description>
+    <Description Lang="en">Change ticket owners easily.</Description>
+    <Description Lang="hu">Jegytulajdonosok egyszerű megváltoztatása.</Description>
     <License>GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007</License>
     <Filelist>
         <File Permission="644" Location="Kernel/Config/Files/QuickOwnerChange.xml" />
+        <File Permission="644" Location="Kernel/Language/de_QuickOwnerChange.pm" />
+        <File Permission="644" Location="Kernel/Language/hu_QuickOwnerChange.pm" />
         <File Permission="644" Location="Kernel/Modules/AgentTicketOwnerChangeBulk.pm" />
         <File Permission="644" Location="Kernel/Output/HTML/FilterElementPost/OwnerChange.pm" />
         <File Permission="644" Location="Kernel/Output/HTML/FilterElementPost/OwnerChangeTicketView.pm" />
@@ -18,5 +21,6 @@
         <File Permission="644" Location="Kernel/Output/HTML/Templates/Standard/QuickOwnerChangeSnippetTicketView.tt" />
         <File Permission="644" Location="doc/QuickOwnerChange.json" />
         <File Permission="644" Location="doc/en/QuickOwnerChange.pod" />
+        <File Permission="644" Location="doc/hu/QuickOwnerChange.pod" />
     </Filelist>
 </otrs_package>

--- a/doc/QuickOwnerChange.json
+++ b/doc/QuickOwnerChange.json
@@ -1,6 +1,6 @@
 {
     "name": "QuickOwnerChange",
-    "version": "5.0.4",
+    "version": "5.0.5",
     "framework": [
         "5.0.x"
     ],
@@ -10,7 +10,8 @@
     },
     "license": "GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007",
     "description" : {
-        "en": "Change ticket owners easily",
-        "de": "Ticketbesitzer leicht wechseln"
+        "en": "Change ticket owners easily.",
+        "de": "Ticketbesitzer leicht wechseln.",
+        "hu": "Jegytulajdonosok egyszerű megváltoztatása."
     }
 }

--- a/doc/hu/QuickOwnerChange.pod
+++ b/doc/hu/QuickOwnerChange.pod
@@ -1,0 +1,40 @@
+=encoding utf-8
+
+=head1 NÉV
+
+QuickOwnerChange - a jegytulajdonos gyors megváltoztatása.
+
+=head1 LEÍRÁS
+
+Ezzel a kiegészítővel egy lenyíló menüt kap a jegynagyításban és a 
+jegyáttekintőben, amely lehetővé teszi a tulajdonos megváltoztatását kettő 
+kattintással.
+
+=head1 KÖSZÖNETNYILVÁNÍTÁS
+
+Szerencsére néhány funkciót támogattak a következő vállalatok:
+
+=over 4
+
+=item * HYDRO Systems
+
+A HYDRO Systems KG L<http://www.hydro.aero/> támogatta azt a funkciót, hogy 
+a felelőst is be lehessen állítani (ugyanarra az ügyintézőre, mint a 
+tulajdonost). Egy további funkciót is támogatott a HYDRO: meghatározhat egy 
+csoportot, hogy a lehetséges tulajdonost ennek a csoportnak a tagjaira 
+korlátozza. Ilyen csoportot minden egyes várólistához meghatározhat.
+
+=back
+
+=head1 SZERZŐ ÉS LICENC
+
+Ezt a csomagot Renée Bäcker E<lt>otrs@perl-services.deE<gt> készítette.
+
+Ez a modul az AGPL 3.0 szerint licencelt. Ha nem kapta meg ezt a fájlt, 
+akkor nézze meg a L<http://www.gnu.org/licenses/agpl.txt> oldalon.
+
+=head1 MAGYAR FORDÍTÁS
+
+A magyar fordítást az OTRS-megoldások csapata készítette.
+Copyright (C) 2016 Úr Balázs, L<http://otrs-megoldasok.hu>
+


### PR DESCRIPTION
Hi @reneeb 
This PR contains the following changes:
- Hungarian language file and translated strings (also in .sopm)
- German language file (needs translation to be finished)
- replaced QuickOwnerChange::NoneLabel SysConfig option with translatable string, as it was not possible to use it in multi-language environments
- changed dropdowns to modern menu
- fixed HTML quoting in template file
- added Hungarian documentation
